### PR TITLE
Quick fix for error when initializing SLDS

### DIFF
--- a/ssm/core.py
+++ b/ssm/core.py
@@ -660,7 +660,7 @@ class BaseSwitchingLDS(object):
                      copy.deepcopy(self.dynamics))
 
         arhmm.fit(xs, inputs=inputs, masks=xmasks, tags=tags,
-                  method="em", num_em_iters=num_em_iters, num_iters=10)
+                  method="em", num_em_iters=num_em_iters)
 
         self.init_state_distn = copy.deepcopy(arhmm.init_state_distn)
         self.transitions = copy.deepcopy(arhmm.transitions)


### PR DESCRIPTION
Do not pass num_iters to fit in initialize.
BaseHMM._fit_em can not take the num_iters argument since commit 38417e5fd33a5926943205b4d49340f31199d7e3.

Fixes #31.