### PR TITLE
added polygamma and digamma imports

### DIFF
--- a/ssm/regression.py
+++ b/ssm/regression.py
@@ -6,6 +6,7 @@ import autograd.numpy as np
 import autograd.numpy.random as npr
 from autograd.scipy.linalg import block_diag
 from autograd.scipy.special import logsumexp, gammaln
+from scipy.special import polygamma, digamma
 from scipy.optimize import minimize
 from warnings import warn
 


### PR DESCRIPTION
these are used in the `generalized_newton_studentst_dof`. It looks like the em step uses the standard `scipy` functions, but please check to make sure you didn't intend to use `autograd`'s versions instead