### PR TITLE
LDS: Change LDS.sample API to return (x, y)

### DIFF
--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -1014,3 +1014,7 @@ class LDS(SLDS):
             assert np.isfinite(elbo)
 
         return elbo / n_samples
+    
+    def sample(self, T, input=None, tag=None, prefix=None, with_noise=True):
+        (_, x, y) = super().sample(T, input=input, tag=tag, prefix=prefix, with_noise=with_noise)
+        return (x, y)

--- a/ssm/observations.py
+++ b/ssm/observations.py
@@ -750,6 +750,23 @@ class AutoRegressiveObservations(_AutoRegressiveObservationsBase):
         self.l2_penalty_b = l2_penalty_b
         self.l2_penalty_V = l2_penalty_V
 
+    @property
+    def A(self):
+        return self.As[0]
+
+    @A.setter
+    def A(self, value):
+        assert value.shape == self.As[0].shape
+        self.As[0] = value
+
+    @property
+    def b(self):
+        return self.bs[0]
+
+    @b.setter
+    def b(self, value):
+        assert value.shape == self.bs[0].shape
+        self.bs[0] == value
 
     @property
     def Sigmas_init(self):


### PR DESCRIPTION
Because LDS subclasses SLDS, the current way of sampling from an LDS is
to do (_, x, y) = LDS.sample(...). This is a bit strange if the user
doesn't know that internally an LDS is built from an SLDS, and we're
just throwing away the discrete state.

Propose explicitly overriding the sample definition, and returning a
tuple (x, y) instead of a tuple (x, y, z).