### PR TITLE
init_state_distns: Add Fixed init state dist

### DIFF
--- a/ssm/hmm.py
+++ b/ssm/hmm.py
@@ -42,9 +42,11 @@ class HMM(object):
         # Make the initial state distribution
         if init_state_distn is None:
             init_state_distn = isd.InitialStateDistribution(K, D, M=M)
-        if not isinstance(init_state_distn, isd.InitialStateDistribution):
+        if not (isinstance(init_state_distn, isd.InitialStateDistribution) \
+            or isinstance(init_state_distn, isd.FixedInitialStateDistribution)):
             raise TypeError("'init_state_distn' must be a subclass of"
-                            " ssm.init_state_distns.InitialStateDistribution")
+                            " ssm.init_state_distns.InitialStateDistribution"
+                            " or ssm.init_state_distns.FixedInitialStateDistribution")
 
         # Make the transition model
         transition_classes = dict(

--- a/ssm/hmm.py
+++ b/ssm/hmm.py
@@ -42,11 +42,9 @@ class HMM(object):
         # Make the initial state distribution
         if init_state_distn is None:
             init_state_distn = isd.InitialStateDistribution(K, D, M=M)
-        if not (isinstance(init_state_distn, isd.InitialStateDistribution) \
-            or isinstance(init_state_distn, isd.FixedInitialStateDistribution)):
+        if not isinstance(init_state_distn, isd.InitialStateDistribution):
             raise TypeError("'init_state_distn' must be a subclass of"
-                            " ssm.init_state_distns.InitialStateDistribution"
-                            " or ssm.init_state_distns.FixedInitialStateDistribution")
+                            " ssm.init_state_distns.InitialStateDistribution.")
 
         # Make the transition model
         transition_classes = dict(

--- a/ssm/init_state_distns.py
+++ b/ssm/init_state_distns.py
@@ -45,3 +45,17 @@ class InitialStateDistribution(object):
     def m_step(self, expectations, datas, inputs, masks, tags, **kwargs):
         pi0 = sum([Ez[0] for Ez, _, _ in expectations]) + 1e-8
         self.log_pi0 = np.log(pi0 / pi0.sum())
+
+
+class FixedInitialStateDistribution(InitialStateDistribution):
+    def __init__(self, K, D, pi0=None, M=0):
+        super(FixedInitialStateDistribution, self).__init__(K, D, M=M)
+        if pi0 is not None:
+            # Handle the case where user passes a numpy array of (K, 1) instead of (K,)
+            pi0 = np.squeeze(np.array(pi0))
+            assert len(pi0) == K, "Array passed as pi0 is of the wrong length"
+            self.log_pi0 = np.log(pi0 + 1e-16)
+
+    def m_step(self, expectations, datas, inputs, masks, tags, **kwargs):
+        # Don't change the distribution
+        pass


### PR DESCRIPTION
Useful for when the user wants to specify the initial state dist by hand.

@slinderman  Is overriding the m-step like this too hacky? 