### PR TITLE
Constrained transitions

### DIFF
--- a/ssm/hmm.py
+++ b/ssm/hmm.py
@@ -51,6 +51,7 @@ class HMM(object):
         transition_classes = dict(
             standard=trans.StationaryTransitions,
             stationary=trans.StationaryTransitions,
+            constrained=trans.ConstrainedStationaryTransitions,
             sticky=trans.StickyTransitions,
             inputdriven=trans.InputDrivenTransitions,
             recurrent=trans.RecurrentTransitions,

--- a/ssm/hmm.py
+++ b/ssm/hmm.py
@@ -478,6 +478,11 @@ class HMM(object):
         if initialize:
             self.initialize(datas, inputs=inputs, masks=masks, tags=tags)
 
+        if isinstance(self.transitions,
+                      trans.ConstrainedStationaryTransitions):
+            if method != "em":
+                raise Exception("Only EM is implemented "
+                                "for Constrained transitions.")
         return _fitting_methods[method](datas, inputs=inputs, masks=masks, tags=tags, **kwargs)
 
 

--- a/ssm/messages.py
+++ b/ssm/messages.py
@@ -187,7 +187,7 @@ def hmm_expected_states(pi0, Ps, ll):
     # M-step is the sum of the expected joints.
     stationary = (Ps.shape[0] == 1)
     if not stationary:
-        expected_joints = alphas[:-1,:,None] + betas[1:,None,:] + ll[1:,None,:] + np.log(Ps + LOG_EPS)
+        expected_joints = alphas[:-1,:,None] + betas[1:,None,:] + ll[1:,None,:] + np.log(Ps)
         expected_joints -= expected_joints.max((1,2))[:,None, None]
         expected_joints = np.exp(expected_joints)
         expected_joints /= expected_joints.sum((1,2))[:,None,None]
@@ -195,7 +195,7 @@ def hmm_expected_states(pi0, Ps, ll):
     else:
         # Compute the sum over time axis of the expected joints
         expected_joints = np.zeros((K, K))
-        _compute_stationary_expected_joints(alphas, betas, ll, np.log(Ps[0] + LOG_EPS), expected_joints)
+        _compute_stationary_expected_joints(alphas, betas, ll, np.log(Ps[0]), expected_joints)
         expected_joints = expected_joints[None, :, :]
 
     return expected_states, expected_joints, normalizer

--- a/ssm/transitions.py
+++ b/ssm/transitions.py
@@ -155,13 +155,14 @@ class ConstrainedStationaryTransitions(StationaryTransitions):
         
         self.transition_mask = transition_mask
         Ps = Ps * transition_mask
-        self.log_Ps = np.log(Ps + LOG_EPS)
+        Ps /= Ps.sum(axis=-1)
+        self.log_Ps = np.log(Ps)
 
     def m_step(self, expectations, datas, inputs, masks, tags, **kwargs):
         P = sum([np.sum(Ezzp1, axis=0) for _, Ezzp1, _ in expectations])
         P *= self.transition_mask
         P /= P.sum(axis=-1, keepdims=True)
-        self.log_Ps = np.log(P + LOG_EPS)
+        self.log_Ps = np.log(P)
 
 class StickyTransitions(StationaryTransitions):
     """

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -82,7 +82,7 @@ def test_constrained_hmm(T=100, K=3, D=3):
     ]).astype(bool)
     init_Ps = np.random.rand(3, 3)
     init_Ps /= init_Ps.sum(axis=-1, keepdims=True)
-    init_log_Ps = np.log(init_Ps + 1e-16)
+    init_log_Ps = np.log(init_Ps)
     transition_kwargs = dict(
         transition_mask=transition_mask
     )
@@ -90,10 +90,9 @@ def test_constrained_hmm(T=100, K=3, D=3):
                   transitions="constrained",
                   observations="gaussian",
                   transition_kwargs=transition_kwargs)
-    fit_hmm.transitions.log_Ps = init_log_Ps
     fit_hmm.fit(x)
     learned_Ps = fit_hmm.transitions.transition_matrix
-    assert np.allclose(learned_Ps[~transition_mask], 0)
+    assert np.all(learned_Ps[~transition_mask] == 0)
 
 
 def test_hmm_likelihood(T=1000, K=5, D=2):
@@ -310,4 +309,5 @@ def test_hmm_likelihood_perf(T=10000, K=50, D=20):
 
 if __name__ == "__main__":
     # test_hmm_likelihood_perf()
-    test_hmm_mp_perf()
+    # test_hmm_mp_perf()
+    test_constrained_hmm()

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -14,6 +14,7 @@ def test_sample(T=10, K=4, D=3, M=2):
     transition_names = [
         "standard",
         "sticky",
+        "constrained",
         "inputdriven",
         "recurrent",
         "recurrent_only",
@@ -66,6 +67,33 @@ def test_sample(T=10, K=4, D=3, M=2):
             hmm = ssm.HMM(K, D, M=M, transitions=transitions, observations=observations)
             zpre, xpre = hmm.sample(3, input=npr.randn(3, M))
             zsmpl, xsmpl = hmm.sample(T, prefix=(zpre, xpre), input=npr.randn(T, M), with_noise=False)
+
+
+def test_constrained_hmm(T=100, K=3, D=3):
+    hmm = ssm.HMM(K, D, M=0, 
+                  transitions="constrained",
+                  observations="gaussian")
+    z, x = hmm.sample(T)
+    
+    transition_mask = np.array([
+        [1, 0, 1],
+        [1, 0, 0],
+        [1, 0, 1],
+    ]).astype(bool)
+    init_Ps = np.random.rand(3, 3)
+    init_Ps /= init_Ps.sum(axis=-1, keepdims=True)
+    init_log_Ps = np.log(init_Ps + 1e-16)
+    transition_kwargs = dict(
+        transition_mask=transition_mask
+    )
+    fit_hmm = ssm.HMM(K, D, M=0, 
+                  transitions="constrained",
+                  observations="gaussian",
+                  transition_kwargs=transition_kwargs)
+    fit_hmm.transitions.log_Ps = init_log_Ps
+    fit_hmm.fit(x)
+    learned_Ps = fit_hmm.transitions.transition_matrix
+    assert np.allclose(learned_Ps[~transition_mask], 0)
 
 
 def test_hmm_likelihood(T=1000, K=5, D=2):


### PR DESCRIPTION
Add a class for constrained stationary transitions for HMMs. This allows the user to specify that some entries of the transition matrix will be zero.  In the current implementation, we allow having _exact_ zeros in the transition matrix for this class (corresponding to -inf in the log transition matrix). This does not interfere with the message passing or log-likelihood calculations for HMMs.

**Note**: This _does not_ allow for having zeros in the transition matrix for an SLDS or RSLDS, only for vanilla HMMs. That will require more careful treatment of the case where end up with 0*log(0) in the ELBO calculation.