### PR TITLE
Exact M-Step for Linear-Gaussian LDS

### DIFF
--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -12,7 +12,7 @@ from ssm.optimizers import adam_step, rmsprop_step, sgd_step, lbfgs, bfgs, \
     convex_combination, adam, sgd, rmsprop, \
     newtons_method_block_tridiag_hessian
 from ssm.primitives import hmm_normalizer, symm_block_tridiag_matmul
-from ssm.messages import hmm_expected_states, viterbi
+from ssm.messages import hmm_expected_states, viterbi, kalman_info_smoother
 from ssm.util import ensure_args_are_lists, \
     ensure_slds_args_not_none, ensure_variational_args_are_lists
 
@@ -633,6 +633,7 @@ J
             h = symm_block_tridiag_matmul(J_diag, J_lower_diag, x)
 
             # update params
+            D = self.D
             prms["J_ini"] = np.zeros((D, D))
             prms["h_ini"] = np.zeros((D,))
             prms["J_dyn_11"] = np.zeros((D, D))
@@ -647,6 +648,13 @@ J
         self, discrete_expectations, continuous_expectations,
         datas, inputs, masks, tags,
         emission_optimizer, emission_optimizer_maxiter, alpha):
+        
+        #TODO: Fix this!! Need to unpack the expectations
+        # and form ExxT for the augmented state vector, then call 
+        # the m_step for autoregressive observations. Also need to 
+        # ensure that we actually can perform the exact mstep for the current
+        # dynamics model before running.
+        raise NotImplementedError
 
         # 3. Update the model parameters.  Replace the expectation wrt x with sample from q(x).
         # The parameter update is partial and depends on alpha.
@@ -778,8 +786,32 @@ J
 
             # 3. Update parameters
             if learning and parameters_update=="exact_mstep":
-
+                # Call Kalman smoother to get expectations
+                Ex, ExxT, ExyT = [], [], []
+                for prms in copy.deepcopy(variational_posterior.params):
+                    # Set the log normalizers to zero since we will not use the
+                    # value of the log-normalizer output. Should not affected
+                    # expected state or covariance calculation.
+                    log_Z_dyn, log_Z_ini, log_Z_obs = 0, 0, 0
+                    log_Z, smoothed_mus, smoothed_sigmas, ExxnT = \
+                        kalman_info_smoother(
+                            prms["J_ini"], prms["h_ini"], log_Z_ini,
+                            prms["J_dyn_11"], prms["J_dyn_21"], 
+                            prms["J_dyn_22"], prms["h_dyn_1"], prms["h_dyn_2"], log_Z_dyn,
+                            prms["J_obs"], prms["h_obs"], log_Z_obs
+                        )
+                    Ex.append(smoothed_mus)
+                    ExxT.append(smoothed_sigmas)
+                    ExyT.append(ExxnT)
+                import pdb
+                pdb.set_trace()
                 self._fit_laplace_em_params_update_exact_mstep(
+                    discrete_expectations, # expectations
+                    Ex, # datas
+                    inputs,
+                    masks,
+                    tags,
+                    continuous_expectations = (ExxT, ExyT)
                     )
 
             # Default is partial M-step given a sample from q(x)

--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -649,7 +649,7 @@ J
             datas, inputs, masks, tags,
             emission_optimizer, emission_optimizer_maxiter,
             alpha, continuous_expectations=None,):
-        
+
         # For now we can only do the exact update with linear-Gaussian dynamics
         # and lags == 1. This check should pass as long as the dynamics is a
         # subclass of AutoRegressiveObservations (e.g
@@ -659,10 +659,12 @@ J
 
         # 3. Update the model parameters exactly
         xmasks = [np.ones_like(x, dtype=bool) for x in continuous_samples]
-        for distn in [self.init_state_distn, self.transitions, self.dynamics]:
+        for distn in [self.init_state_distn, self.transitions]:
             if distn.params == tuple(): continue
-            distn.m_step(expectations, continuous_samples, inputs, xmasks, tags, 
-                         continuous_expectations=continuous_expectations)
+            distn.m_step(expectations, continuous_samples, inputs, xmasks,
+                         tags)
+        self.dynamics.m_step(expectations, continuous_samples, inputs, xmasks,
+                             tags)
 
         # update emissions params. For now, the emissions update will be
         # approximate.
@@ -801,13 +803,13 @@ J
                     log_Z, smoothed_mus, smoothed_sigmas, ExxnT = \
                         kalman_info_smoother(
                             prms["J_ini"], prms["h_ini"], log_Z_ini,
-                            prms["J_dyn_11"], prms["J_dyn_21"], 
+                            prms["J_dyn_11"], prms["J_dyn_21"],
                             prms["J_dyn_22"], prms["h_dyn_1"], prms["h_dyn_2"], log_Z_dyn,
                             prms["J_obs"], prms["h_obs"], log_Z_obs
                         )
                     # we should cache everything from the kalman smoother into variational
                     # posterior
-                    Ex.append(smoothed_mus) 
+                    Ex.append(smoothed_mus)
                     mumuT = np.swapaxes(smoothed_mus[:, None], 2,1) @ smoothed_mus[:, None]
                     ExxT.append(smoothed_sigmas + mumuT)
                     ExyT.append(ExxnT)

--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -645,7 +645,7 @@ J
             prms["h_obs"] = h
 
     def _fit_laplace_em_params_update_exact_mstep(
-            self, expectations, continuous_sample,
+            self, expectations, continuous_samples,
             datas, inputs, masks, tags, continuous_expectations=None):
         
         # For now we can only do the exact update with linear-Gaussian dynamics
@@ -656,17 +656,17 @@ J
             "We can only do an exact m-step with Linear-Gaussian Dynamics."
 
         # 3. Update the model parameters exactly
-        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_sample]
+        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_samples]
         for distn in [self.init_state_distn, self.transitions, self.dynamics]:
             if distn.params == tuple(): continue
-            distn.m_step(expectations, continuous_sample, inputs, xmasks, tags, 
+            distn.m_step(expectations, continuous_samples, inputs, xmasks, tags, 
                          continuous_expectations=continuous_expectations)
 
         # update emissions params. For now, the emissions update will be
         # approximate. TODO: Does using a convex combination mess up the
         # orthogonal emissions models?
         curr_prms = copy.deepcopy(self.emissions.params)
-        self.emissions.m_step(discrete_expectations, continuous_sample,
+        self.emissions.m_step(discrete_expectations, continuous_samples,
                               datas, inputs, masks, tags,
                               optimizer=emission_optimizer,
                               maxiter=emission_optimizer_maxiter)
@@ -674,22 +674,22 @@ J
 
 
     def _fit_laplace_em_params_update_stoch_mstep(
-        self, discrete_expectations, continuous_sample,
+        self, discrete_expectations, continuous_samples,
         datas, inputs, masks, tags,
         emission_optimizer, emission_optimizer_maxiter, alpha):
 
         # 3. Update the model parameters.  Replace the expectation wrt x with sample from q(x).
         # The parameter update is partial and depends on alpha.
-        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_sample]
+        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_samples]
         for distn in [self.init_state_distn, self.transitions, self.dynamics]:
             curr_prms = copy.deepcopy(distn.params)
             if curr_prms == tuple(): continue
-            distn.m_step(discrete_expectations, continuous_sample, inputs, xmasks, tags)
+            distn.m_step(discrete_expectations, continuous_samples, inputs, xmasks, tags)
             distn.params = convex_combination(curr_prms, distn.params, alpha)
 
         # update emissions params
         curr_prms = copy.deepcopy(self.emissions.params)
-        self.emissions.m_step(discrete_expectations, continuous_sample,
+        self.emissions.m_step(discrete_expectations, continuous_samples,
                               datas, inputs, masks, tags,
                               optimizer=emission_optimizer,
                               maxiter=emission_optimizer_maxiter)
@@ -723,14 +723,14 @@ J
         for sample in range(n_samples):
 
             # sample continuous states
-            continuous_samples = variational_posterior.sample_continuous_states()
+            continuous_sampless = variational_posterior.sample_continuous_states()
             discrete_expectations = variational_posterior.mean_discrete_states
 
             # log p(theta)
             elbo += self.log_prior()
 
             for x, (Ez, Ezzp1, _), data, input, mask, tag in \
-                zip(continuous_samples, discrete_expectations, datas, inputs, masks, tags):
+                zip(continuous_sampless, discrete_expectations, datas, inputs, masks, tags):
 
                 # The "mask" for x is all ones
                 x_mask = np.ones_like(x, dtype=bool)
@@ -745,7 +745,7 @@ J
                 elbo += np.sum(Ez * log_likes)
 
             # add entropy of variational posterior
-            elbo += variational_posterior.entropy(continuous_samples)
+            elbo += variational_posterior.entropy(continuous_sampless)
 
         return elbo / n_samples
 
@@ -784,7 +784,7 @@ J
                 continuous_optimizer, continuous_tolerance, continuous_maxiter)
 
             # 3. Update parameters
-            continuous_sample = variational_posterior.sample_continuous_states()
+            continuous_samples = variational_posterior.sample_continuous_states()
             if learning and parameters_update=="exact_mstep":
                 # Call Kalman smoother to get expectations
                 Ex, ExxT, ExyT = [], [], []
@@ -803,14 +803,12 @@ J
                     Ex.append(smoothed_mus)
                     ExxT.append(smoothed_sigmas)
                     ExyT.append(ExxnT)
-                    import pdb
-                    pdb.set_trace()
 
                 self._fit_laplace_em_params_update_exact_mstep(
                     discrete_expectations,
                     # In the exact, the sample of the continuous sates
                     # won't be needed, but we pass it for consistency.
-                    continuous_sample,
+                    continuous_samples,
                     datas,
                     inputs,
                     masks,
@@ -821,7 +819,7 @@ J
             # Default is partial M-step given a sample from q(x)
             elif learning and parameters_update=="stoch_mstep":
                 self._fit_laplace_em_params_update_stoch_mstep(
-                    discrete_expectations, continuous_sample, datas, inputs, masks, tags,
+                    discrete_expectations, continuous_samples, datas, inputs, masks, tags,
                     emission_optimizer, emission_optimizer_maxiter, alpha)
 
             # Alternative is SGD on all parameters with samples from q(x)

--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -646,7 +646,9 @@ J
 
     def _fit_laplace_em_params_update_exact_mstep(
             self, expectations, continuous_samples,
-            datas, inputs, masks, tags, continuous_expectations=None):
+            datas, inputs, masks, tags,
+            emission_optimizer, emission_optimizer_maxiter,
+            alpha, continuous_expectations=None,):
         
         # For now we can only do the exact update with linear-Gaussian dynamics
         # and lags == 1. This check should pass as long as the dynamics is a
@@ -663,10 +665,10 @@ J
                          continuous_expectations=continuous_expectations)
 
         # update emissions params. For now, the emissions update will be
-        # approximate. TODO: Does using a convex combination mess up the
-        # orthogonal emissions models?
+        # approximate.
+        # TODO: check if emissions linear gaussian and do exact m-step if so.
         curr_prms = copy.deepcopy(self.emissions.params)
-        self.emissions.m_step(discrete_expectations, continuous_samples,
+        self.emissions.m_step(expectations, continuous_samples,
                               datas, inputs, masks, tags,
                               optimizer=emission_optimizer,
                               maxiter=emission_optimizer_maxiter)
@@ -779,6 +781,9 @@ J
             discrete_expectations = variational_posterior.mean_discrete_states
 
             # 2. Update the continuous state posterior q(x)
+            #    TODO: We are throwing away the log-normalizer from
+            #    variational_posterior.mean_discrete_states() when we coud be
+            #    using it in the ELBO calculations.
             self._fit_laplace_em_continuous_state_update(
                 discrete_expectations, variational_posterior, datas, inputs, masks, tags,
                 continuous_optimizer, continuous_tolerance, continuous_maxiter)
@@ -800,8 +805,11 @@ J
                             prms["J_dyn_22"], prms["h_dyn_1"], prms["h_dyn_2"], log_Z_dyn,
                             prms["J_obs"], prms["h_obs"], log_Z_obs
                         )
-                    Ex.append(smoothed_mus)
-                    ExxT.append(smoothed_sigmas)
+                    # we should cache everything from the kalman smoother into variational
+                    # posterior
+                    Ex.append(smoothed_mus) 
+                    mumuT = np.swapaxes(smoothed_mus[:, None], 2,1) @ smoothed_mus[:, None]
+                    ExxT.append(smoothed_sigmas + mumuT)
                     ExyT.append(ExxnT)
 
                 self._fit_laplace_em_params_update_exact_mstep(
@@ -813,7 +821,10 @@ J
                     inputs,
                     masks,
                     tags,
-                    continuous_expectations=(Ex, ExxT, ExyT)
+                    emission_optimizer,
+                    emission_optimizer_maxiter,
+                    alpha,
+                    continuous_expectations=(Ex, ExxT, ExyT),
                     )
 
             # Default is partial M-step given a sample from q(x)

--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -762,7 +762,7 @@ J
                         continuous_maxiter=100,
                         emission_optimizer="lbfgs",
                         emission_optimizer_maxiter=100,
-                        parameters_update="stoch_mstep",
+                        parameters_update=None,
                         alpha=0.5,
                         learning=True):
         """
@@ -775,6 +775,15 @@ J
         elbos = [self._laplace_em_elbo(variational_posterior, datas, inputs, masks, tags)]
         pbar = trange(num_iters)
         pbar.set_description("ELBO: {:.1f}".format(elbos[-1]))
+
+        # Default to an exact parameters update when possible.
+        if parameters_update is None:
+            if isinstance(self.dynamics, obs.AutoRegressiveObservations):
+                if self.dynamics.lags == 1:
+                    parameters_update = "exact_mstep"
+            else:
+                parameters_update = "stoch_mstep"
+
         for itr in pbar:
             # 1. Update the discrete state posterior q(z) if K>1
             if self.K > 1:
@@ -841,6 +850,10 @@ J
                     variational_posterior, datas, inputs, masks, tags,
                     emission_optimizer="adam",
                     emission_optimizer_maxiter=emission_optimizer_maxiter)
+
+            elif learning:
+                raise ValueError("Invalid argument for parameters_update: {}. " \
+                    "Must be one of: stoch_mstep, exact_mstep, sgd.".format(parameters_update))
 
             # 4. Compute ELBO
             elbo = self._laplace_em_elbo(variational_posterior, datas, inputs, masks, tags)

--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -645,29 +645,28 @@ J
             prms["h_obs"] = h
 
     def _fit_laplace_em_params_update_exact_mstep(
-        self, discrete_expectations, continuous_expectations,
-        datas, inputs, masks, tags,
-        emission_optimizer, emission_optimizer_maxiter, alpha):
+            self, expectations, continuous_sample,
+            datas, inputs, masks, tags, continuous_expectations=None):
         
-        #TODO: Fix this!! Need to unpack the expectations
-        # and form ExxT for the augmented state vector, then call 
-        # the m_step for autoregressive observations. Also need to 
-        # ensure that we actually can perform the exact mstep for the current
-        # dynamics model before running.
-        raise NotImplementedError
+        # For now we can only do the exact update with linear-Gaussian dynamics
+        # and lags == 1. This check should pass as long as the dynamics is a
+        # subclass of AutoRegressiveObservations (e.g
+        # AutoRegressiveObservationsNoInput)
+        assert isinstance(self.dynamics, obs.AutoRegressiveObservations), \
+            "We can only do an exact m-step with Linear-Gaussian Dynamics."
 
-        # 3. Update the model parameters.  Replace the expectation wrt x with sample from q(x).
-        # The parameter update is partial and depends on alpha.
-        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_expectations]
+        # 3. Update the model parameters exactly
+        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_sample]
         for distn in [self.init_state_distn, self.transitions, self.dynamics]:
-            curr_prms = copy.deepcopy(distn.params)
-            if curr_prms == tuple(): continue
-            distn.m_step(discrete_expectations, continuous_expectations, inputs, xmasks, tags)
-            distn.params = convex_combination(curr_prms, distn.params, alpha)
+            if distn.params == tuple(): continue
+            distn.m_step(expectations, continuous_sample, inputs, xmasks, tags, 
+                         continuous_expectations=continuous_expectations)
 
-        # update emissions params
+        # update emissions params. For now, the emissions update will be
+        # approximate. TODO: Does using a convex combination mess up the
+        # orthogonal emissions models?
         curr_prms = copy.deepcopy(self.emissions.params)
-        self.emissions.m_step(discrete_expectations, continuous_expectations,
+        self.emissions.m_step(discrete_expectations, continuous_sample,
                               datas, inputs, masks, tags,
                               optimizer=emission_optimizer,
                               maxiter=emission_optimizer_maxiter)
@@ -675,22 +674,22 @@ J
 
 
     def _fit_laplace_em_params_update_stoch_mstep(
-        self, discrete_expectations, continuous_expectations,
+        self, discrete_expectations, continuous_sample,
         datas, inputs, masks, tags,
         emission_optimizer, emission_optimizer_maxiter, alpha):
 
         # 3. Update the model parameters.  Replace the expectation wrt x with sample from q(x).
         # The parameter update is partial and depends on alpha.
-        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_expectations]
+        xmasks = [np.ones_like(x, dtype=bool) for x in continuous_sample]
         for distn in [self.init_state_distn, self.transitions, self.dynamics]:
             curr_prms = copy.deepcopy(distn.params)
             if curr_prms == tuple(): continue
-            distn.m_step(discrete_expectations, continuous_expectations, inputs, xmasks, tags)
+            distn.m_step(discrete_expectations, continuous_sample, inputs, xmasks, tags)
             distn.params = convex_combination(curr_prms, distn.params, alpha)
 
         # update emissions params
         curr_prms = copy.deepcopy(self.emissions.params)
-        self.emissions.m_step(discrete_expectations, continuous_expectations,
+        self.emissions.m_step(discrete_expectations, continuous_sample,
                               datas, inputs, masks, tags,
                               optimizer=emission_optimizer,
                               maxiter=emission_optimizer_maxiter)
@@ -785,12 +784,13 @@ J
                 continuous_optimizer, continuous_tolerance, continuous_maxiter)
 
             # 3. Update parameters
+            continuous_sample = variational_posterior.sample_continuous_states()
             if learning and parameters_update=="exact_mstep":
                 # Call Kalman smoother to get expectations
                 Ex, ExxT, ExyT = [], [], []
                 for prms in copy.deepcopy(variational_posterior.params):
                     # Set the log normalizers to zero since we will not use the
-                    # value of the log-normalizer output. Should not affected
+                    # value of the log-normalizer output. Should not affect
                     # expected state or covariance calculation.
                     log_Z_dyn, log_Z_ini, log_Z_obs = 0, 0, 0
                     log_Z, smoothed_mus, smoothed_sigmas, ExxnT = \
@@ -803,20 +803,23 @@ J
                     Ex.append(smoothed_mus)
                     ExxT.append(smoothed_sigmas)
                     ExyT.append(ExxnT)
-                import pdb
-                pdb.set_trace()
+                    import pdb
+                    pdb.set_trace()
+
                 self._fit_laplace_em_params_update_exact_mstep(
-                    discrete_expectations, # expectations
-                    Ex, # datas
+                    discrete_expectations,
+                    # In the exact, the sample of the continuous sates
+                    # won't be needed, but we pass it for consistency.
+                    continuous_sample,
+                    datas,
                     inputs,
                     masks,
                     tags,
-                    continuous_expectations = (ExxT, ExyT)
+                    continuous_expectations=(Ex, ExxT, ExyT)
                     )
 
             # Default is partial M-step given a sample from q(x)
             elif learning and parameters_update=="stoch_mstep":
-                continuous_sample = variational_posterior.sample_continuous_states()
                 self._fit_laplace_em_params_update_stoch_mstep(
                     discrete_expectations, continuous_sample, datas, inputs, masks, tags,
                     emission_optimizer, emission_optimizer_maxiter, alpha)

--- a/ssm/messages.py
+++ b/ssm/messages.py
@@ -81,7 +81,7 @@ def hmm_filter(pi0, Ps, ll):
         pz_tt[t] = np.exp(alphas[t] - m)
         pz_tt[t] /= np.sum(pz_tt[t])
         pz_tp1t[t] = pz_tt[t].dot(Ps[hetero*t])
- 
+
     # Include the initial state distribution
     # Numba's version of vstack requires all arrays passed to vstack
     # to have the same number of dimensions.
@@ -89,7 +89,7 @@ def hmm_filter(pi0, Ps, ll):
     pz_tp1t = np.vstack((pi0, pz_tp1t))
 
     # Numba implementation of np.sum does not allow axis keyword arg,
-    # and does not support np.allclose, so we loop over the time range 
+    # and does not support np.allclose, so we loop over the time range
     # to verify that each sums to 1.
     for t in range(T):
         assert np.abs(np.sum(pz_tp1t[t]) - 1.0) < 1e-8
@@ -943,7 +943,7 @@ def kalman_info_wrapper(f):
         assert h_dyn_2.shape == (T-1, D) or h_dyn_2.shape == (D,)
         assert np.isscalar(log_Z_dyn) or log_Z_dyn.shape == (T-1,)
         assert J_obs.shape == (T, D, D)
-        assert log_Z_obs.shape == (T,)
+        assert np.isscalar(log_Z_obs) or log_Z_obs.shape == (T,)
 
         # Add extra time dimension if necessary
         J_dyn_11 = J_dyn_11 if J_dyn_11.ndim == 3 else np.reshape(J_dyn_11, (1,) + J_dyn_11.shape)
@@ -953,6 +953,7 @@ def kalman_info_wrapper(f):
         h_dyn_2 = h_dyn_2 if h_dyn_2.ndim == 2 else np.reshape(h_dyn_2, (1,) + h_dyn_2.shape)
         log_Z_dyn = np.array([log_Z_dyn]) if np.isscalar(log_Z_dyn) else log_Z_dyn
         J_obs = J_obs if J_obs.ndim == 3 else np.reshape(J_obs, (1,) + J_obs.shape)
+        log_Z_obs = np.array([log_Z_obs]) if np.isscalar(log_Z_obs) else log_Z_obs
 
         return f(J_ini, h_ini, log_Z_ini,
                  J_dyn_11, J_dyn_21, J_dyn_22, h_dyn_1, h_dyn_2, log_Z_dyn,
@@ -1126,7 +1127,7 @@ def test_info_sample(T=100, D=3, N=10, U=3):
     # Test the standard Kalman filter
     from pylds.lds_messages_interface import E_step as kalman_smoother_ref
     ll1, smoothed_mus1, smoothed_Sigmas1, ExnxT1 = kalman_smoother_ref(*args)
-    
+
     # Plot_the samples vs the smoother
     info_args = convert_mean_to_info_args(*args)
     xs = [kalman_info_sample(*info_args) for _ in range(4)]

--- a/ssm/observations.py
+++ b/ssm/observations.py
@@ -894,82 +894,89 @@ class AutoRegressiveObservations(_AutoRegressiveObservationsBase):
 
     def m_step(self, expectations, datas, inputs, masks, tags,
                J0=None, h0=None, continuous_expectations=None):
+        """Compute M-step for Gaussian Auto Regressive Observations.
+
+        If `continuous_expectations` is not None, this function will
+        compute an exact M-step using the expected sufficient statistics for the
+        continuous states. In this case, we ignore the prior provided by (J0, h0),
+        because the calculation is exact.
+
+        If `continuous_expectations` is None, we fall back to an approximate M-step,
+        using the prior given by (J0, h0). In this case, we estimate the sufficient
+        statistics using `datas,` which is typically a single sample of the continuous
+        states from the posterior distribution. 
+        """
         K, D, M, lags = self.K, self.D, self.M, self.lags
 
+        As = np.zeros((K, D, D * lags + M))
+        bs = np.zeros((K, D))
+        Sigmas = np.zeros((K, D, D))
+        Ex, Ey, ExxT, ExyT, EyyT = (None, None, None, None, None)
+        xs, ys, Ezs = [], [], []
+        for (Ez, _, _), data, input, mask, tag in zip(expectations, datas, inputs, masks, tags):
+            if not np.all(mask):
+                raise Exception("Encountered missing data in AutoRegressiveObservations!")
+            # Since the fit_linear_regression function includes an intercept, we
+            # don't need to append the intercept to the xs
+            xs.append(
+                np.hstack([data[self.lags-l-1:-l-1] for l in range(self.lags)]
+                          + [input[self.lags:, :self.M]])
+            )
+            ys.append(data[self.lags:])
+            Ezs.append(Ez[self.lags:])
+
         if continuous_expectations is None:
-            # Collect all the data
-            xs, ys, Ezs = [], [], []
-            for (Ez, _, _), data, input, mask, tag in zip(expectations, datas, inputs, masks, tags):
-                # Only use data if it is complete
-                if not np.all(mask):
-                    raise Exception("Encountered missing data in AutoRegressiveObservations!")
-
-                xs.append(
-                    np.hstack([data[self.lags-l-1:-l-1] for l in range(self.lags)]
-                              + [input[self.lags:, :self.M], np.ones((data.shape[0]-self.lags, 1))]))
-                ys.append(data[self.lags:])
-                Ezs.append(Ez[self.lags:])
-
-            # M step: Fit the weighted linear regressions for each K and D
-            if J0 is None and h0 is None:
-                J_diag = np.concatenate((self.l2_penalty_A * np.ones(D * lags),
-                                     self.l2_penalty_V * np.ones(M),
-                                     self.l2_penalty_b * np.ones(1)))
-                Ex = np.zeros((K, D * lags + M + 1))
-                Ey = np.zeros((K, D))
-                ExxT = np.tile(np.diag(J_diag)[None, :, :], (K, 1, 1))
-                ExyT = np.zeros((K, D * lags + M + 1, D))
-                EyyT = np.zeros((K, D, D))
+            # We are performing an approximate m-step here. 
+            # Collect all the data and pass it to fit_linear_regression.
+            if J0 is not None:
+                    J = J0
             else:
-                # Use J0 and h0 as a prior on A, b
-                assert J0.shape == (K, D*lags + M + 1, D*lags + M + 1)
-                assert h0.shape == (K, D*lags + M + 1, D)
-                Ex = np.zeros((K, D * lags + M + 1))
-                Ey = np.zeros((K, D))
-                ExxT = J0
-                ExyT = h0
-                EyyT = np.zeros((K, D, D))
+                J_diag = np.concatenate((self.l2_penalty_A * np.ones(D * lags),
+                                        self.l2_penalty_V * np.ones(M),
+                                        self.l2_penalty_b * np.ones(1)))
+                J = np.tile(np.diag(J_diag)[None, :, :], (K, 1, 1))
+            if h0 is not None:
+                h = h0
+            else:
+                h = np.zeros((K, D + M + 1, D))
 
-            for x, y, Ez in zip(xs, ys, Ezs):
-                # Einsum is concise but slow!
-                # J += np.einsum('tk, ti, tj -> kij', Ez, x, x)
-                # h += np.einsum('tk, ti, td -> kid', Ez, x, y)
-                # Do weighted products for each of the k states
-                for k in range(K):
-                    weighted_x = x * Ez[:, k:k+1]
-                    weighted_y = y * Ez[:, k:k+1]
-                    Ex[k] = np.sum(weighted_x, axis=0)
-                    Ey[k] = np.sum(weighted_y, axis=0)
-                    ExxT[k] += np.dot(weighted_x.T, x)
-                    ExyT[k] += np.dot(weighted_x.T, y)
-                    EyyT[k] += np.dot(weighted_y.T, y)
+            for k in range(K):
+                weights_curr = [Ez[:, k] for Ez in Ezs]
+                A_curr, b_curr, sigma_curr = fit_linear_regression(xs, ys,
+                                        weights=weights_curr,
+                                        fit_intercept=True,
+                                        prior_ExxT=J[k],
+                                        prior_ExyT=h[k],
+                                        Psi0=1e-8,
+                                        nu0=1e-8,
+                                    )
+                As[k] = A_curr
+                bs[k] = b_curr
+                Sigmas[k] = sigma_curr
         else:
-            # Continuous expectations are given
+            # Continuous expectations are given. We are performing an exact
+            # m-step. Pass the sufficient statistics to fit_linear_regression
+            # along with the data.
             Ex, Ey, ExxT, ExyT, EyyT = continuous_expectations
+            for k in range(K):
+                weights_curr = [Ez[:, k] for Ez in Ezs]
+                A_curr, b_curr, sigma_curr = fit_linear_regression(
+                                    xs,
+                                    ys,
+                                    weights=weights_curr,
+                                    fit_intercept=True,
+                                    expectations=(ExxT, ExyT)
+                                    )
+                As[k] = A_curr
+                bs[k] = b_curr
+                Sigmas[k] = sigma_curr
 
-        # Solve for the linear regression weights
-        mus = np.linalg.solve(ExxT, ExyT)
-        self.As = np.swapaxes(mus[:, :D*lags, :], 1, 2)
-        self.Vs = np.swapaxes(mus[:, D*lags:D*lags+M, :], 1, 2)
-        self.bs = mus[:, -1, :]
-
-        # TODO: Update the covariance using the expected sufficient statistics
-        # E[(y - Ax - b)(y - Ax - b)^T]
-        # = E[yy^T -2yx^TA^T - 2yb^T +Axx^TA^T + 2Axb^T + bb^T]
-        #
-        # In the above, A is a block matrix [A V b] (mus in the code above)
-        
-        A = np.swapaxes(mus, 1, 2) 
-        AT = mus
-        expected_err = EyyT - 2 * A @ ExyT + A @ ExxT @ AT
-        
-        weight = 1e-32 * np.ones(K)
-        for (Ez, _, _) in expectations:
-            weight += np.sum(Ez, axis=0)
-        Sigmas = expected_err / weight[:, None, None] + 1e-32 * np.eye(D)
+        self.As = As
+        self.bs = bs
+        self.Sigmas = Sigmas
 
         # If any states are unused, set their parameters to a perturbation of a used state
-        usage = sum([Ez.sum(0) for (Ez, _, _) in Ezs])
+        usage = sum([Ez.sum(0) for Ez in Ezs])
         unused = np.where(usage < 1)[0]
         used = np.where(usage > 1)[0]
         if len(unused) > 0:
@@ -978,10 +985,8 @@ class AutoRegressiveObservations(_AutoRegressiveObservationsBase):
                 self.As[k] = self.As[i] + 0.01 * npr.randn(*self.As[i].shape)
                 self.Vs[k] = self.Vs[i] + 0.01 * npr.randn(*self.Vs[i].shape)
                 self.bs[k] = self.bs[i] + 0.01 * npr.randn(*self.bs[i].shape)
-                Sigmas[k] = Sigmas[i]
+                self.Sigmas[k] = Sigmas[i]
 
-        # Store the updated covariances
-        self.Sigmas = Sigmas
 
     def sample_x(self, z, xhist, input=None, tag=None, with_noise=True):
         D, As, bs, Vs = self.D, self.As, self.bs, self.Vs

--- a/ssm/observations.py
+++ b/ssm/observations.py
@@ -1016,12 +1016,12 @@ class AutoRegressiveObservations(_AutoRegressiveObservationsBase):
                 A_curr, b_curr, sigma_curr = fit_linear_regression(
                                     xs,
                                     ys,
-                                    weights=weights_curr,
+                                    weights=None,
                                     fit_intercept=True,
-                                    # TODO: Add 4th expectation to account for # of time-steps
                                     expectations=(ExxT_aug,
                                                   ExyT_aug,
-                                                  EyyT[k])
+                                                  EyyT[k],
+                                                  pz_equal_k)
                                     )
                 As[k] = A_curr
                 bs[k] = b_curr

--- a/ssm/util.py
+++ b/ssm/util.py
@@ -238,3 +238,7 @@ def collapse(x, state_map, axis=-1):
                                   axis=axis, keepdims=True)
                            for k in range(K)], axis=axis)
 
+
+def check_shape(var, var_name, desired_shape):
+    assert var.shape == desired_shape, "Variable {} is of wrong shape. "\
+        "Expected {}, found {}.".format(var_name, desired_shape, var.shape)

--- a/ssm/variational.py
+++ b/ssm/variational.py
@@ -337,6 +337,9 @@ class SLDSStructuredMeanFieldVariationalPosterior(VariationalPosterior):
     def mean_discrete_states(self):
         # Now compute the posterior expectations of z under q(z)
         # NOTE: This returns the log normalizer, E[z_t], E[z_t, z_{t+1}]
+        # TODO: cache expectations and log normalizer here, so that they are
+        # available for computing entropies, but need to be sure that the parameters
+        # haven't changed.
         return [hmm_expected_states(prms["pi0"], prms["Ps"], prms["log_likes"])
                 for prms in self.params]
 
@@ -397,8 +400,12 @@ class SLDSStructuredMeanFieldVariationalPosterior(VariationalPosterior):
 
             # 1. Compute log q(x) of samples of x
             # TODO: Compute the exact entropy
-            raise NotImplementedError
-            negentropy += block_tridiagonal_log_probability(s, prms["J_diag"], prms["J_lower_diag"], prms["h"])
+            J_diag = prms["J_obs"]
+            J_lower_diag = prms["J_dyn_21"]
+            h = prms["h_obs"]
+            negentropy += block_tridiagonal_log_probability(s,
+                                                            J_diag,
+                                                            J_lower_diag, h)
 
             # 2. Compute E_{q(z)}[ log q(z) ]
             log_pi0 = np.log(prms["pi0"] + 1e-16) - logsumexp(prms["pi0"])


### PR DESCRIPTION
Allow an exact M-Step when dynamics are Linear-Gaussian and lags=1. Requires passing `parameters_update="exact_mstep"` to the fit function. Tested (hastily) with LDS, SLDS, and RSLDS. The exact m-step does _not_ always give better convergence than the approximate M-Step, but it does allow for setting constraints on the transition model.

- Create separate codepath in `fit_laplace_em` which calls an exact or an approximate m-step.
- Add function `_fit_laplace_em_params_update_exact_mstep` for the exact case.
- Refactors fit_linear_regression (in regression.py) to allow passing sufficient statistics directly.

Currently, the entropy calculation is still approximate. This will be addressed separately.