### PR TITLE
Remove J0 and h0 args for Robust AR M-step

### DIFF
--- a/ssm/lds.py
+++ b/ssm/lds.py
@@ -580,7 +580,12 @@ class SLDS(object):
                       masks=xmasks,
                       tags=tags
         )
-        if isinstance(self.dynamics, obs.AutoRegressiveObservations) and self.dynamics.lags == 1:
+        exact_m_step_dynamics = [
+           obs.AutoRegressiveObservations,
+           obs.AutoRegressiveObservationsNoInput,
+           obs.AutoRegressiveDiagonalNoiseObservations, 
+        ]
+        if type(self.dynamics) in exact_m_step_dynamics and self.dynamics.lags == 1:
             # In this case, we can do an exact M-step on the dynamics by passing
             # in the true sufficient statistics for the continuous state.
             kwargs["continuous_expectations"] = variational_posterior.continuous_expectations

--- a/ssm/observations.py
+++ b/ssm/observations.py
@@ -1491,8 +1491,8 @@ class _RobustAutoRegressiveObservationsMixin(object):
             # M step: Fit the weighted linear regressions for each K and D
             # This is exactly the same as the M-step for the AutoRegressiveObservations,
             # but it has an extra scaling factor of tau applied to the weight.
-            J = self.J0
-            h = self.h0
+            J = self.J0.copy()
+            h = self.h0.copy()
             for x, y, Ez, tau in zip(xs, ys, Ezs, taus):
                 weight = Ez * tau
                 # Einsum is concise but slow!


### PR DESCRIPTION
This is so that the RobustAR observations are compatible with the changes introduced in ede3eb97 and
3940c0a039. Also, fix bug where we would try to do the exact M-Step for RobustAR observations (and
hence fitting would fail).